### PR TITLE
Allow for custom namespacing

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -35,6 +35,11 @@ class Updater
     private $disk;
 
     /**
+     * @var string
+     */
+    private $baseNamespace = '\\App\\';
+
+    /**
      * Get files in sync directory.
      *
      * @param  string|null  $path
@@ -52,6 +57,16 @@ class Updater
 
         $this->directory = $this->getDirectory($path);
         $this->files = $this->getFiles($this->directory, $model);
+    }
+
+    /**
+     * Override the default namespace for the class.
+     *
+     * @param $namespace
+     */
+    public function setNamespace($namespace)
+    {
+        $this->baseNamespace = $namespace;
     }
 
     /**
@@ -232,7 +247,7 @@ class Updater
      */
     protected function getModel(string $name)
     {
-        return '\\App\\'.Str::studly(pathinfo($name, PATHINFO_FILENAME));
+        return $this->baseNamespace.Str::studly(pathinfo($name, PATHINFO_FILENAME));
     }
 
     /**


### PR DESCRIPTION
New method allows for customization of the namespace of the models. This is specially useful for when this package is being consumed by another package where the models are in a custom namespace.

## Usage Example

~~~php
$updater = new Updater('data-sync', null, true));
$updater->setNamespace('\\nullthoughts\\Models\\');
$updater->run();
~~~